### PR TITLE
feat: split preview UX improvements and empty state redesign

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tabby-tabbyspaces",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tabby-tabbyspaces",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "@angular/common": "^15.0.0",

--- a/src/components/paneEditor.component.pug
+++ b/src/components/paneEditor.component.pug
@@ -7,6 +7,14 @@
 
   .pane-form
     .form-group
+      label Name
+      input.form-control(
+        type='text',
+        [(ngModel)]='pane.name',
+        placeholder='Optional pane name'
+      )
+
+    .form-group
       label Profile
       select.form-control([(ngModel)]='pane.profileId')
         option(value='') -- Select Profile --

--- a/src/components/splitPreview.component.pug
+++ b/src/components/splitPreview.component.pug
@@ -1,5 +1,14 @@
 .split-preview([class.horizontal]='split.orientation === "horizontal"', [class.vertical]='split.orientation === "vertical"', [class.nested]='depth > 0')
   ng-container(*ngFor='let child of split.children; let i = index')
+    //- Resize handle between children
+    .resize-handle(
+      *ngIf='i > 0',
+      [class.horizontal]='split.orientation === "horizontal"',
+      [class.vertical]='split.orientation === "vertical"',
+      [class.dragging]='resizing && resizeIndex === i - 1',
+      (mousedown)='onResizeStart($event, i - 1)'
+    )
+
     //- Pane
     .preview-pane(
       *ngIf='isPane(child)',
@@ -9,15 +18,18 @@
       (contextmenu)='onContextMenu($event, asPane(child))'
     )
       .pane-content
-        .pane-label
-          | {{ getPaneLabel(asPane(child)) }}
-        .pane-details
-          .pane-detail(*ngIf='asPane(child).cwd', [title]='asPane(child).cwd')
-            i.fas.fa-folder
-            span {{ truncate(asPane(child).cwd, 20) }}
-          .pane-detail(*ngIf='asPane(child).startupCommand', [title]='asPane(child).startupCommand')
-            i.fas.fa-terminal
-            span {{ truncate(asPane(child).startupCommand, 20) }}
+        .pane-title
+          span.pane-name(*ngIf='asPane(child).name') {{ asPane(child).name }}
+          span.pane-sep(*ngIf='asPane(child).name')  -
+          span.pane-profile {{ getPaneLabel(asPane(child)) }}
+        .pane-path(*ngIf='asPane(child).cwd') {{ asPane(child).cwd }}
+        .pane-command(*ngIf='asPane(child).startupCommand')
+          i.fas.fa-terminal
+          |  {{ asPane(child).startupCommand }}
+      .pane-dimensions
+        span.dim-value {{ getPaneGlobalWidth(i) }}
+        span.dim-sep  :
+        span.dim-value {{ getPaneGlobalHeight(i) }}
 
     //- Nested split
     split-preview(
@@ -26,6 +38,8 @@
       [depth]='depth + 1',
       [selectedPaneId]='selectedPaneId',
       [profiles]='profiles',
+      [globalWidthRatio]='getChildGlobalWidth(i)',
+      [globalHeightRatio]='getChildGlobalHeight(i)',
       [style.flex-basis]='getFlexStyle(i)',
       (paneEdit)='onNestedPaneEdit($event)',
       (splitHorizontal)='onNestedSplitH($event)',
@@ -34,7 +48,9 @@
       (addRight)='onNestedAddRight($event)',
       (addTop)='onNestedAddTop($event)',
       (addBottom)='onNestedAddBottom($event)',
-      (removePane)='onNestedRemove($event)'
+      (removePane)='onNestedRemove($event)',
+      (ratioChange)='onNestedRatioChange()',
+      (resizeEnd)='onNestedResizeEnd()'
     )
 
 //- Context menu

--- a/src/components/splitPreview.component.scss
+++ b/src/components/splitPreview.component.scss
@@ -3,8 +3,7 @@
 .split-preview {
   display: flex;
   width: 100%;
-  height: $preview-height;
-  gap: $spacing-sm;
+  height: 100%;
   border-radius: $radius-md;
   overflow: hidden;
   background: var(--theme-bg);
@@ -20,10 +19,55 @@
 
   &.nested {
     height: auto;
-    border: 1px dashed var(--theme-fg-more);
+    border: 1px dashed rgba(255, 255, 255, 0.08);
     background: $nested-split-bg;
     padding: $spacing-sm;
     border-radius: $radius-sm;
+  }
+}
+
+.resize-handle {
+  flex: 0 0 6px;
+  position: relative;
+  z-index: 1;
+  user-select: none;
+
+  &.horizontal {
+    cursor: col-resize;
+  }
+
+  &.vertical {
+    cursor: row-resize;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    border-radius: 1px;
+    background: var(--theme-border, $fallback-border);
+    transition: background $transition-fast;
+  }
+
+  &.horizontal::after {
+    top: 20%;
+    bottom: 20%;
+    left: 2px;
+    width: 2px;
+  }
+
+  &.vertical::after {
+    left: 20%;
+    right: 20%;
+    top: 2px;
+    height: 2px;
+  }
+
+  &:hover::after {
+    background: var(--theme-fg-more, rgba(255, 255, 255, 0.4));
+  }
+
+  &.dragging::after {
+    background: var(--theme-primary);
   }
 }
 
@@ -53,47 +97,73 @@
 }
 
 .pane-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1px;
   text-align: center;
-  padding: $spacing-md;
+  padding: $spacing-sm $spacing-md;
   color: var(--theme-fg);
   max-width: 100%;
   overflow: hidden;
 }
 
-.pane-label {
-  font-size: 0.85rem;
-  font-weight: 600;
-  margin-bottom: $spacing-sm;
-  @include text-ellipsis;
-}
-
-.pane-title,
-.pane-profile {
-  font-size: 0.8rem;
+.pane-title {
+  font-size: 0.75rem;
   font-weight: 500;
-  margin-bottom: $spacing-xs;
-  @include text-ellipsis;
+  overflow-wrap: break-word;
+
+  .pane-name {
+    font-weight: 600;
+  }
+
+  .pane-sep {
+    opacity: 0.4;
+  }
+
+  .pane-profile {
+    opacity: 0.8;
+  }
 }
 
-.pane-details {
-  font-size: 0.7rem;
+.pane-path {
+  font-size: 0.6rem;
+  opacity: 0.6;
+  word-break: break-all;
+}
+
+.pane-command {
+  font-size: 0.55rem;
+  opacity: 0.5;
+  overflow-wrap: break-word;
+
+  i {
+    font-size: 0.5rem;
+  }
+}
+
+.pane-dimensions {
+  position: absolute;
+  bottom: $spacing-xs;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: baseline;
+  font-size: 0.65rem;
+  pointer-events: none;
+  color: var(--theme-primary);
+  white-space: nowrap;
   opacity: 0.7;
-  margin-top: $spacing-sm;
 
-  .pane-detail {
-    @include flex-center;
-    gap: $spacing-sm;
+  .dim-value {
+    min-width: 2.5em;
+    text-align: center;
+  }
 
-    i {
-      width: 12px;
-      text-align: center;
-      font-size: 0.65rem;
-    }
-
-    span {
-      @include text-ellipsis;
-      max-width: 100px;
-    }
+  .dim-sep {
+    opacity: 0.5;
+    margin: 0 2px;
   }
 }
 

--- a/src/components/splitPreview.component.ts
+++ b/src/components/splitPreview.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, Output, EventEmitter, OnChanges, SimpleChanges, ChangeDetectorRef } from '@angular/core'
+import { Component, Input, Output, EventEmitter, OnChanges, OnDestroy, SimpleChanges, ChangeDetectorRef, ElementRef } from '@angular/core'
 import {
   WorkspaceSplit,
   WorkspacePane,
@@ -11,11 +11,13 @@ import {
   template: require('./splitPreview.component.pug'),
   styles: [require('./splitPreview.component.scss')],
 })
-export class SplitPreviewComponent implements OnChanges {
+export class SplitPreviewComponent implements OnChanges, OnDestroy {
   @Input() split!: WorkspaceSplit
   @Input() depth = 0
   @Input() selectedPaneId: string | null = null
   @Input() profiles: TabbyProfile[] = []
+  @Input() globalWidthRatio = 1
+  @Input() globalHeightRatio = 1
   @Output() paneEdit = new EventEmitter<WorkspacePane>()
   @Output() splitHorizontal = new EventEmitter<WorkspacePane>()
   @Output() splitVertical = new EventEmitter<WorkspacePane>()
@@ -24,17 +26,31 @@ export class SplitPreviewComponent implements OnChanges {
   @Output() addRight = new EventEmitter<WorkspacePane>()
   @Output() addTop = new EventEmitter<WorkspacePane>()
   @Output() addBottom = new EventEmitter<WorkspacePane>()
+  @Output() ratioChange = new EventEmitter<void>()
+  @Output() resizeEnd = new EventEmitter<void>()
 
   contextMenuPane: WorkspacePane | null = null
   contextMenuPosition = { x: 0, y: 0 }
 
-  constructor(private cdr: ChangeDetectorRef) {}
+  // Drag state
+  resizing = false
+  wasResizing = false
+  resizeIndex = -1
+  private resizeContainerRect: DOMRect | null = null
+  private boundOnResizeMove: ((e: MouseEvent) => void) | null = null
+  private boundOnResizeEnd: (() => void) | null = null
+
+  constructor(private cdr: ChangeDetectorRef, private elementRef: ElementRef) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     // Clear context menu when split input changes to avoid stale state
     if (changes['split']) {
       this.closeContextMenu()
     }
+  }
+
+  ngOnDestroy(): void {
+    this.cleanupDragListeners()
   }
 
   isPane(child: WorkspacePane | WorkspaceSplit): boolean {
@@ -58,13 +74,8 @@ export class SplitPreviewComponent implements OnChanges {
   }
 
   onPaneClick(pane: WorkspacePane): void {
+    if (this.wasResizing) return
     this.paneEdit.emit(pane)
-  }
-
-  truncate(text: string, maxLength: number): string {
-    return text.length > maxLength
-      ? text.substring(0, maxLength) + '...'
-      : text
   }
 
   onContextMenu(event: MouseEvent, pane: WorkspacePane): void {
@@ -134,11 +145,103 @@ export class SplitPreviewComponent implements OnChanges {
     }
   }
 
+  getChildGlobalWidth(index: number): number {
+    return this.split.orientation === 'horizontal'
+      ? this.globalWidthRatio * this.split.ratios[index]
+      : this.globalWidthRatio
+  }
+
+  getChildGlobalHeight(index: number): number {
+    return this.split.orientation === 'vertical'
+      ? this.globalHeightRatio * this.split.ratios[index]
+      : this.globalHeightRatio
+  }
+
+  getPaneGlobalWidth(index: number): string {
+    return Math.round(this.getChildGlobalWidth(index) * 100) + '%'
+  }
+
+  getPaneGlobalHeight(index: number): string {
+    return Math.round(this.getChildGlobalHeight(index) * 100) + '%'
+  }
+
   getPaneLabel(pane: WorkspacePane): string {
     if (!pane.profileId) return 'Select profile'
 
     const profile = this.profiles.find(p => p.id === pane.profileId)
     return profile?.name || 'Select profile'
+  }
+
+  // Resize handle drag logic
+  onResizeStart(event: MouseEvent, handleIndex: number): void {
+    event.preventDefault()
+    event.stopPropagation()
+
+    this.resizeIndex = handleIndex
+    this.resizing = true
+
+    const container = this.elementRef.nativeElement.querySelector('.split-preview')
+    this.resizeContainerRect = container.getBoundingClientRect()
+
+    this.boundOnResizeMove = this.onResizeMove.bind(this)
+    this.boundOnResizeEnd = this.onResizeEnd.bind(this)
+    document.addEventListener('mousemove', this.boundOnResizeMove)
+    document.addEventListener('mouseup', this.boundOnResizeEnd)
+  }
+
+  private onResizeMove(event: MouseEvent): void {
+    if (!this.resizing || !this.resizeContainerRect) return
+
+    const k = this.resizeIndex
+    const isHorizontal = this.split.orientation === 'horizontal'
+    const containerStart = isHorizontal ? this.resizeContainerRect.left : this.resizeContainerRect.top
+    const containerSize = isHorizontal ? this.resizeContainerRect.width : this.resizeContainerRect.height
+    const mousePos = isHorizontal ? event.clientX : event.clientY
+
+    // Calculate offset: sum of ratios before the left child
+    let offset = 0
+    for (let i = 0; i < k; i++) {
+      offset += this.split.ratios[i]
+    }
+
+    const combined = this.split.ratios[k] + this.split.ratios[k + 1]
+    const mouseRatio = (mousePos - containerStart) / containerSize
+
+    // Snap to nearest 0.1
+    let newLeft = Math.round((mouseRatio - offset) / 0.1) * 0.1
+
+    // Clamp
+    newLeft = Math.max(0.1, Math.min(combined - 0.1, newLeft))
+
+    // Only update if changed
+    if (Math.abs(this.split.ratios[k] - newLeft) > 0.001) {
+      this.split.ratios[k] = newLeft
+      this.split.ratios[k + 1] = combined - newLeft
+      this.ratioChange.emit()
+      this.cdr.detectChanges()
+    }
+  }
+
+  private onResizeEnd(): void {
+    this.resizing = false
+    this.wasResizing = true
+    setTimeout(() => { this.wasResizing = false }, 0)
+    this.resizeIndex = -1
+    this.resizeContainerRect = null
+    this.cleanupDragListeners()
+    this.resizeEnd.emit()
+    this.cdr.detectChanges()
+  }
+
+  private cleanupDragListeners(): void {
+    if (this.boundOnResizeMove) {
+      document.removeEventListener('mousemove', this.boundOnResizeMove)
+      this.boundOnResizeMove = null
+    }
+    if (this.boundOnResizeEnd) {
+      document.removeEventListener('mouseup', this.boundOnResizeEnd)
+      this.boundOnResizeEnd = null
+    }
   }
 
   // Pass-through events from nested splits
@@ -172,5 +275,15 @@ export class SplitPreviewComponent implements OnChanges {
 
   onNestedRemove(pane: WorkspacePane): void {
     this.removePane.emit(pane)
+  }
+
+  onNestedRatioChange(): void {
+    this.ratioChange.emit()
+  }
+
+  onNestedResizeEnd(): void {
+    this.wasResizing = true
+    setTimeout(() => { this.wasResizing = false }, 0)
+    this.resizeEnd.emit()
   }
 }

--- a/src/components/workspaceEditor.component.pug
+++ b/src/components/workspaceEditor.component.pug
@@ -69,7 +69,7 @@
             )
 
 //- Section 2: Split Layout
-.editor-section
+.editor-section.layout-section
   .section-title
     i.fas.fa-columns
     |  Split Layout
@@ -142,7 +142,9 @@
         (addRight)='addPaneFromEvent($event, "right")',
         (addTop)='addPaneFromEvent($event, "top")',
         (addBottom)='addPaneFromEvent($event, "bottom")',
-        (removePane)='removePane($event)'
+        (removePane)='removePane($event)',
+        (ratioChange)='onRatioChange()',
+        (resizeEnd)='onResizeEnd()'
       )
 
     //- Inline pane editor

--- a/src/components/workspaceEditor.component.scss
+++ b/src/components/workspaceEditor.component.scss
@@ -1,8 +1,22 @@
 @use '../styles/index' as *;
 
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 // Editor section
 .editor-section {
   margin-bottom: $spacing-xl;
+
+  &.layout-section {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
 }
 
 .section-title {
@@ -80,7 +94,7 @@
 .icon-dropdown {
   position: absolute;
   top: 100%;
-  left: 0;
+  right: 0;
   margin-top: $spacing-sm;
   padding: $spacing-md;
   @include dropdown-panel;
@@ -189,7 +203,6 @@
 .background-dropdown {
   position: absolute;
   top: 100%;
-  left: 0;
   right: 0;
   margin-top: $spacing-sm;
   padding: $spacing-md;
@@ -235,6 +248,10 @@
 
 // Split preview container
 .split-preview-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
   background: var(--theme-bg-more);
   border: 1px solid var(--theme-border, $fallback-border);
   border-radius: $radius-md;
@@ -266,10 +283,11 @@
 
 // Layout preview area
 .layout-preview {
+  flex: 1;
+  display: flex;
   background: var(--theme-bg);
   border-radius: $radius-sm;
   min-height: 150px;
-  max-height: 200px;
   padding: $spacing-sm;
 }
 
@@ -278,9 +296,9 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding-top: $spacing-xl;
+  padding-top: $spacing-lg;
   border-top: 1px solid var(--theme-border, $fallback-border);
-  margin-top: $spacing-xl;
+  margin-top: auto;
 }
 
 .checkbox-group {
@@ -304,6 +322,7 @@
 .action-buttons-right {
   display: flex;
   gap: $spacing-md;
+  align-items: stretch;
 
   .btn-ghost {
     @include btn-ghost;
@@ -312,6 +331,7 @@
   .btn-success {
     @include btn-base;
     @include btn-success;
+    border: 1px solid $color-success;
   }
 
   .unsaved-indicator {

--- a/src/components/workspaceList.component.pug
+++ b/src/components/workspaceList.component.pug
@@ -1,6 +1,6 @@
 .workspace-list-container
   //- Tab bar navigation
-  .tab-bar
+  .tab-bar(*ngIf='workspaces.length > 0 || editingWorkspace')
     .tab(
       *ngFor='let tab of displayTabs; trackBy: trackByTab',
       [class.active]='isTabSelected(tab)',
@@ -30,8 +30,11 @@
     )
 
   //- Empty state (when no workspaces)
-  .tab-content.empty-state(*ngIf='!editingWorkspace && workspaces.length === 0')
-    p No workspaces configured yet.
-    p Click
-      strong +
-      | to create your first workspace.
+  .empty-state(*ngIf='!editingWorkspace && workspaces.length === 0')
+    .empty-state-icon
+      i.fas.fa-columns
+    h2.empty-state-title TabbySpaces
+    p.empty-state-description Create custom split layouts with profiles, working directories, and startup commands.
+    button.empty-state-cta((click)='createWorkspace()')
+      i.fas.fa-plus
+      | Create Workspace

--- a/src/components/workspaceList.component.scss
+++ b/src/components/workspaceList.component.scss
@@ -1,7 +1,18 @@
 @use '../styles/index' as *;
 
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 .workspace-list-container {
   padding: $spacing-2xl;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
 }
 
 // Tab bar
@@ -109,19 +120,43 @@
   border: 1px solid var(--theme-border, $fallback-border);
   border-top: none;
   padding: $spacing-xl;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
 
-  &.empty-state {
-    text-align: center;
-    padding: $spacing-2xl;
-    color: var(--theme-fg-more);
+// Empty state
+.empty-state {
+  @include flex-center;
+  flex-direction: column;
+  padding: 80px $spacing-2xl;
+  text-align: center;
+  flex: 1;
+}
 
-    p {
-      margin: $spacing-md 0;
-    }
+.empty-state-icon {
+  font-size: 2.5rem;
+  color: var(--theme-fg-more, $fallback-fg-more);
+  margin-bottom: $spacing-xl;
+  opacity: 0.5;
+}
 
-    strong {
-      color: var(--theme-primary);
-      padding: 0 $spacing-xs;
-    }
-  }
+.empty-state-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--theme-fg);
+  margin: 0 0 $spacing-md;
+}
+
+.empty-state-description {
+  font-size: $font-sm;
+  color: var(--theme-fg-more, $fallback-fg-more);
+  margin: 0 0 $spacing-2xl;
+  max-width: 320px;
+  line-height: 1.5;
+}
+
+.empty-state-cta {
+  @include btn-primary;
 }

--- a/src/components/workspaceList.component.ts
+++ b/src/components/workspaceList.component.ts
@@ -16,7 +16,7 @@ import {
   isWorkspaceSplit,
 } from '../models/workspace.model'
 
-const SETTINGS_MAX_WIDTH = '876px'
+const SETTINGS_MAX_WIDTH = 'none'
 
 @Component({
   selector: 'workspace-list',
@@ -54,12 +54,26 @@ export class WorkspaceListComponent implements OnInit, OnDestroy, AfterViewInit 
   }
 
   ngAfterViewInit(): void {
-    // Hack: Override Tabby's settings-tab-body max-width restriction
+    // Hack: Override Tabby's settings layout restrictions to fill entire page
     setTimeout(() => {
-      const parent = this.elementRef.nativeElement.closest('settings-tab-body') as HTMLElement
-      if (parent) {
-        parent.style.maxWidth = SETTINGS_MAX_WIDTH
+      const settingsTabBody = this.elementRef.nativeElement.closest('settings-tab-body') as HTMLElement
+      if (settingsTabBody) {
+        settingsTabBody.style.maxWidth = SETTINGS_MAX_WIDTH
+        settingsTabBody.style.height = '100%'
+
+        // .tab-pane needs height instead of just min-height
+        const tabPane = settingsTabBody.closest('.tab-pane') as HTMLElement
+        if (tabPane) {
+          tabPane.style.height = '100%'
+          tabPane.style.boxSizing = 'border-box'
+        }
       }
+
+      // Make our host element fill the container
+      const host = this.elementRef.nativeElement as HTMLElement
+      host.style.display = 'flex'
+      host.style.flexDirection = 'column'
+      host.style.height = '100%'
     }, 0)
   }
 

--- a/src/models/workspace.model.ts
+++ b/src/models/workspace.model.ts
@@ -58,6 +58,7 @@ export interface TabbySplitLayoutProfile {
 // Workspace interfaces
 export interface WorkspacePane {
   id: string
+  name?: string
   profileId: string
   cwd?: string
   startupCommand?: string

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -173,6 +173,7 @@
 // ======================
 
 @mixin dropdown-panel {
+  background-color: #1e1e1e;
   background: var(--theme-bg-more);
   border: 1px solid var(--theme-border, $fallback-border);
   border-radius: $radius-md;


### PR DESCRIPTION
## Summary

- **Drag-to-resize handles** on the split preview — drag borders between panes to adjust ratios (snaps to 10% increments)
- **Ratio preservation** when splitting or adding panes — no more equal-reset, the new pane gets half of the target pane's share
- **Selection preserved during resize** — clicking a resize handle no longer accidentally selects/deselects panes
- **Preview fills available space** — flex layout stretches the split preview to use the full settings page height instead of being capped at 200px
- **Optional pane name** — new `name` field on the pane model and editor, displayed prominently in the preview
- **Redesigned pane display** — centered hierarchy showing name > profile > path > command with full paths (no more truncation)
- **Percentage labels** — each pane shows its effective width : height dimensions
- **Empty state redesign** — new landing screen with icon, title, description, and a "Create Workspace" CTA button when no workspaces exist
- **Dropdown positioning fixes** — icon and color picker dropdowns align properly
- **Solid background fallback** for dropdown panels

## Files changed

| File | Changes |
|------|---------|
| `src/models/workspace.model.ts` | Added optional `name` field to `WorkspacePane` |
| `src/components/splitPreview.component.*` | Resize handles, drag logic, pane content redesign, percentage labels |
| `src/components/workspaceEditor.component.*` | Ratio change/resize-end bindings, flex stretch layout, dropdown fixes |
| `src/components/workspaceList.component.*` | Empty state redesign, full-height layout, tab bar conditional visibility |
| `src/components/paneEditor.component.pug` | Name input field |
| `src/styles/_mixins.scss` | Solid background fallback for dropdown-panel mixin |
| `package-lock.json` | Version sync to 0.2.0 |

## Test plan

- [ ] Create a new workspace and verify the empty state CTA works
- [ ] Add multiple panes and drag resize handles to adjust ratios
- [ ] Verify ratios are preserved when splitting/adding panes
- [ ] Verify pane selection is not affected by resizing
- [ ] Test pane name field in the pane editor
- [ ] Verify percentage labels show correct dimensions
- [ ] Check dropdown positioning for icon and color pickers
- [ ] Test with nested splits (horizontal inside vertical and vice versa)

🤖 Generated with [Claude Code](https://claude.com/claude-code)